### PR TITLE
Added BankAccountId, Currency, and Property properties to Details for new creditor events.

### DIFF
--- a/src/GoCardless.Api/Events/Details.cs
+++ b/src/GoCardless.Api/Events/Details.cs
@@ -2,9 +2,12 @@
 {
     public class Details
     {
+        public string BankAccountId { get; set; }
         public string Cause { get; set; }
+        public string Currency { get; set; }
         public string Description { get; set; }
         public string Origin { get; set; }
+        public string Property { get; set; }
         public string ReasonCode { get; set; }
 
         /// <summary>

--- a/src/GoCardless.Api/Events/EventLinks.cs
+++ b/src/GoCardless.Api/Events/EventLinks.cs
@@ -2,6 +2,7 @@
 {
     public class EventLinks
     {
+        public string Creditor { get; set; }
         public string Mandate { get; set; }
         public string NewCustomerBankAccount { get; set; }
         public string NewMandate { get; set; }

--- a/src/GoCardless.Api/Events/ResourceType.cs
+++ b/src/GoCardless.Api/Events/ResourceType.cs
@@ -2,7 +2,7 @@
 {
     public static class ResourceType
     {
-        public static readonly string Creditor = "creditors";
+        public static readonly string Creditors = "creditors";
         public static readonly string InstalmentSchedules = "instalment_schedules";
         public static readonly string Mandates = "mandates";
         public static readonly string Payments = "payments";

--- a/tests/GoCardless.Api.Tests.Integration/Clients/EventClientTests.cs
+++ b/tests/GoCardless.Api.Tests.Integration/Clients/EventClientTests.cs
@@ -3,6 +3,7 @@ using GoCardlessApi.Tests.Integration.TestHelpers;
 using NUnit.Framework;
 using System;
 using System.Linq;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 
 namespace GoCardlessApi.Tests.Integration.Clients
@@ -22,21 +23,21 @@ namespace GoCardlessApi.Tests.Integration.Clients
         {
             // given
             // when
-            var result = (await _subject.GetPageAsync()).Items.ToList();
+            var results = (await _subject.GetPageAsync()).Items.ToList();
 
             // then
-            Assert.That(result.Any(), Is.True);
-            Assert.That(result[0], Is.Not.Null);
-            Assert.That(result[0].Id, Is.Not.Null);
-            Assert.That(result[0].Action, Is.Not.Null);
-            Assert.That(result[0].CreatedAt, Is.Not.Null.And.Not.EqualTo(default(DateTimeOffset)));
-            Assert.That(result[0].Details, Is.Not.Null);
-            Assert.That(result[0].Details.Cause, Is.Not.Null);
-            Assert.That(result[0].Details.Description, Is.Not.Null);
-            Assert.That(result[0].Details.Origin, Is.Not.Null);
-            Assert.That(result[0].Links, Is.Not.Null);
-            Assert.That(result[0].Metadata, Is.Not.Null);
-            Assert.That(result[0].ResourceType, Is.Not.Null);
+            Assert.That(results.Any(), Is.True);
+            Assert.That(results[0], Is.Not.Null);
+            Assert.That(results[0].Id, Is.Not.Null);
+            Assert.That(results[0].Action, Is.Not.Null);
+            Assert.That(results[0].CreatedAt, Is.Not.Null.And.Not.EqualTo(default(DateTimeOffset)));
+            Assert.That(results[0].Details, Is.Not.Null);
+            Assert.That(results[0].Details.Cause, Is.Not.Null);
+            Assert.That(results[0].Details.Description, Is.Not.Null);
+            Assert.That(results[0].Details.Origin, Is.Not.Null);
+            Assert.That(results[0].Links, Is.Not.Null);
+            Assert.That(results[0].Metadata, Is.Not.Null);
+            Assert.That(results[0].ResourceType, Is.Not.Null);
         }
 
         [Test]
@@ -50,23 +51,23 @@ namespace GoCardlessApi.Tests.Integration.Clients
             };
 
             // when
-            var result = (await _subject.GetPageAsync(options)).Items.ToList();
+            var results = (await _subject.GetPageAsync(options)).Items.ToList();
 
             // then
-            Assert.That(result.Any(), Is.True);
-            Assert.That(result[0], Is.Not.Null);
-            Assert.That(result[0].Id, Is.Not.Null);
-            Assert.That(result[0].Action, Is.EqualTo(Actions.Creditor.Updated));
-            Assert.That(result[0].CreatedAt, Is.Not.Null.And.Not.EqualTo(default(DateTimeOffset)));
-            Assert.That(result[0].Details, Is.Not.Null);
-            Assert.That(result[0].Details.Cause, Is.EqualTo(Causes.CreditorUpdated));
-            Assert.That(result[0].Details.Description, Is.Not.Null);
-            Assert.That(result[0].Details.Origin, Is.Not.Null);
-            Assert.That(result[0].Details.Property, Is.Not.Null);
-            Assert.That(result[0].Links, Is.Not.Null);
-            Assert.That(result[0].Links.Creditor, Is.Not.Null);
-            Assert.That(result[0].Metadata, Is.Not.Null);
-            Assert.That(result[0].ResourceType, Is.EqualTo(ResourceType.Creditors));
+            Assert.That(results.Any(), Is.True);
+            Assert.That(results[0], Is.Not.Null);
+            Assert.That(results[0].Id, Is.Not.Null);
+            Assert.That(results[0].Action, Is.EqualTo(Actions.Creditor.Updated));
+            Assert.That(results[0].CreatedAt, Is.Not.Null.And.Not.EqualTo(default(DateTimeOffset)));
+            Assert.That(results[0].Details, Is.Not.Null);
+            Assert.That(results[0].Details.Cause, Is.EqualTo(Causes.CreditorUpdated));
+            Assert.That(results[0].Details.Description, Is.Not.Null);
+            Assert.That(results[0].Details.Origin, Is.Not.Null);
+            Assert.That(results[0].Details.Property, Is.Not.Null);
+            Assert.That(results[0].Links, Is.Not.Null);
+            Assert.That(results[0].Links.Creditor, Is.Not.Null);
+            Assert.That(results[0].Metadata, Is.Not.Null);
+            Assert.That(results[0].ResourceType, Is.EqualTo(ResourceType.Creditors));
         }
 
         [Test]
@@ -79,22 +80,22 @@ namespace GoCardlessApi.Tests.Integration.Clients
             };
 
             // when
-            var result = (await _subject.GetPageAsync(options)).Items.ToList();
+            var results = (await _subject.GetPageAsync(options)).Items.ToList();
 
             // then
-            Assert.That(result.Any(), Is.True);
-            Assert.That(result[0], Is.Not.Null);
-            Assert.That(result[0].Id, Is.Not.Null);
-            Assert.That(result[0].Action, Is.Not.Null);
-            Assert.That(result[0].CreatedAt, Is.Not.Null.And.Not.EqualTo(default(DateTimeOffset)));
-            Assert.That(result[0].Details, Is.Not.Null);
-            Assert.That(result[0].Details.Cause, Is.Not.Null);
-            Assert.That(result[0].Details.Description, Is.Not.Null);
-            Assert.That(result[0].Details.Origin, Is.Not.Null);
-            Assert.That(result[0].Links, Is.Not.Null);
-            Assert.That(result[0].Links.Mandate, Is.Not.Null);
-            Assert.That(result[0].Metadata, Is.Not.Null);
-            Assert.That(result[0].ResourceType, Is.EqualTo(ResourceType.Mandates));
+            Assert.That(results.Any(), Is.True);
+            Assert.That(results[0], Is.Not.Null);
+            Assert.That(results[0].Id, Is.Not.Null);
+            Assert.That(results[0].Action, Is.Not.Null);
+            Assert.That(results[0].CreatedAt, Is.Not.Null.And.Not.EqualTo(default(DateTimeOffset)));
+            Assert.That(results[0].Details, Is.Not.Null);
+            Assert.That(results[0].Details.Cause, Is.Not.Null);
+            Assert.That(results[0].Details.Description, Is.Not.Null);
+            Assert.That(results[0].Details.Origin, Is.Not.Null);
+            Assert.That(results[0].Links, Is.Not.Null);
+            Assert.That(results[0].Links.Mandate, Is.Not.Null);
+            Assert.That(results[0].Metadata, Is.Not.Null);
+            Assert.That(results[0].ResourceType, Is.EqualTo(ResourceType.Mandates));
         }
 
         [Test]
@@ -107,22 +108,22 @@ namespace GoCardlessApi.Tests.Integration.Clients
             };
 
             // when
-            var result = (await _subject.GetPageAsync(options)).Items.ToList();
+            var results = (await _subject.GetPageAsync(options)).Items.ToList();
 
             // then
-            Assert.That(result.Any(), Is.True);
-            Assert.That(result[0], Is.Not.Null);
-            Assert.That(result[0].Id, Is.Not.Null);
-            Assert.That(result[0].Action, Is.Not.Null);
-            Assert.That(result[0].CreatedAt, Is.Not.Null.And.Not.EqualTo(default(DateTimeOffset)));
-            Assert.That(result[0].Details, Is.Not.Null);
-            Assert.That(result[0].Details.Cause, Is.Not.Null);
-            Assert.That(result[0].Details.Description, Is.Not.Null);
-            Assert.That(result[0].Details.Origin, Is.Not.Null);
-            Assert.That(result[0].Links, Is.Not.Null);
-            Assert.That(result[0].Links.Payment, Is.Not.Null);
-            Assert.That(result[0].Metadata, Is.Not.Null);
-            Assert.That(result[0].ResourceType, Is.EqualTo(ResourceType.Payments));
+            Assert.That(results.Any(), Is.True);
+            Assert.That(results[0], Is.Not.Null);
+            Assert.That(results[0].Id, Is.Not.Null);
+            Assert.That(results[0].Action, Is.Not.Null);
+            Assert.That(results[0].CreatedAt, Is.Not.Null.And.Not.EqualTo(default(DateTimeOffset)));
+            Assert.That(results[0].Details, Is.Not.Null);
+            Assert.That(results[0].Details.Cause, Is.Not.Null);
+            Assert.That(results[0].Details.Description, Is.Not.Null);
+            Assert.That(results[0].Details.Origin, Is.Not.Null);
+            Assert.That(results[0].Links, Is.Not.Null);
+            Assert.That(results[0].Links.Payment, Is.Not.Null);
+            Assert.That(results[0].Metadata, Is.Not.Null);
+            Assert.That(results[0].ResourceType, Is.EqualTo(ResourceType.Payments));
         }
 
         [Test]
@@ -135,22 +136,22 @@ namespace GoCardlessApi.Tests.Integration.Clients
             };
 
             // when
-            var result = (await _subject.GetPageAsync(options)).Items.ToList();
+            var results = (await _subject.GetPageAsync(options)).Items.ToList();
 
             // then
-            Assert.That(result.Any(), Is.True);
-            Assert.That(result[0], Is.Not.Null);
-            Assert.That(result[0].Id, Is.Not.Null);
-            Assert.That(result[0].Action, Is.Not.Null);
-            Assert.That(result[0].CreatedAt, Is.Not.Null.And.Not.EqualTo(default(DateTimeOffset)));
-            Assert.That(result[0].Details, Is.Not.Null);
-            Assert.That(result[0].Details.Cause, Is.Not.Null);
-            Assert.That(result[0].Details.Description, Is.Not.Null);
-            Assert.That(result[0].Details.Origin, Is.Not.Null);
-            Assert.That(result[0].Links, Is.Not.Null);
-            Assert.That(result[0].Links.Payout, Is.Not.Null);
-            Assert.That(result[0].Metadata, Is.Not.Null);
-            Assert.That(result[0].ResourceType, Is.EqualTo(ResourceType.Payouts));
+            Assert.That(results.Any(), Is.True);
+            Assert.That(results[0], Is.Not.Null);
+            Assert.That(results[0].Id, Is.Not.Null);
+            Assert.That(results[0].Action, Is.Not.Null);
+            Assert.That(results[0].CreatedAt, Is.Not.Null.And.Not.EqualTo(default(DateTimeOffset)));
+            Assert.That(results[0].Details, Is.Not.Null);
+            Assert.That(results[0].Details.Cause, Is.Not.Null);
+            Assert.That(results[0].Details.Description, Is.Not.Null);
+            Assert.That(results[0].Details.Origin, Is.Not.Null);
+            Assert.That(results[0].Links, Is.Not.Null);
+            Assert.That(results[0].Links.Payout, Is.Not.Null);
+            Assert.That(results[0].Metadata, Is.Not.Null);
+            Assert.That(results[0].ResourceType, Is.EqualTo(ResourceType.Payouts));
         }
 
         [Test]
@@ -163,22 +164,22 @@ namespace GoCardlessApi.Tests.Integration.Clients
             };
 
             // when
-            var result = (await _subject.GetPageAsync(options)).Items.ToList();
+            var results = (await _subject.GetPageAsync(options)).Items.ToList();
 
             // then
-            Assert.That(result.Any(), Is.True);
-            Assert.That(result[0], Is.Not.Null);
-            Assert.That(result[0].Id, Is.Not.Null);
-            Assert.That(result[0].Action, Is.Not.Null);
-            Assert.That(result[0].CreatedAt, Is.Not.Null.And.Not.EqualTo(default(DateTimeOffset)));
-            Assert.That(result[0].Details, Is.Not.Null);
-            Assert.That(result[0].Details.Cause, Is.Not.Null);
-            Assert.That(result[0].Details.Description, Is.Not.Null);
-            Assert.That(result[0].Details.Origin, Is.Not.Null);
-            Assert.That(result[0].Links, Is.Not.Null);
-            Assert.That(result[0].Links.Refund, Is.Not.Null);
-            Assert.That(result[0].Metadata, Is.Not.Null);
-            Assert.That(result[0].ResourceType, Is.EqualTo(ResourceType.Refunds));
+            Assert.That(results.Any(), Is.True);
+            Assert.That(results[0], Is.Not.Null);
+            Assert.That(results[0].Id, Is.Not.Null);
+            Assert.That(results[0].Action, Is.Not.Null);
+            Assert.That(results[0].CreatedAt, Is.Not.Null.And.Not.EqualTo(default(DateTimeOffset)));
+            Assert.That(results[0].Details, Is.Not.Null);
+            Assert.That(results[0].Details.Cause, Is.Not.Null);
+            Assert.That(results[0].Details.Description, Is.Not.Null);
+            Assert.That(results[0].Details.Origin, Is.Not.Null);
+            Assert.That(results[0].Links, Is.Not.Null);
+            Assert.That(results[0].Links.Refund, Is.Not.Null);
+            Assert.That(results[0].Metadata, Is.Not.Null);
+            Assert.That(results[0].ResourceType, Is.EqualTo(ResourceType.Refunds));
         }
 
         [Test]
@@ -191,22 +192,22 @@ namespace GoCardlessApi.Tests.Integration.Clients
             };
 
             // when
-            var result = (await _subject.GetPageAsync(options)).Items.ToList();
+            var results = (await _subject.GetPageAsync(options)).Items.ToList();
 
             // then
-            Assert.That(result.Any(), Is.True);
-            Assert.That(result[0], Is.Not.Null);
-            Assert.That(result[0].Id, Is.Not.Null);
-            Assert.That(result[0].Action, Is.Not.Null);
-            Assert.That(result[0].CreatedAt, Is.Not.Null.And.Not.EqualTo(default(DateTimeOffset)));
-            Assert.That(result[0].Details, Is.Not.Null);
-            Assert.That(result[0].Details.Cause, Is.Not.Null);
-            Assert.That(result[0].Details.Description, Is.Not.Null);
-            Assert.That(result[0].Details.Origin, Is.Not.Null);
-            Assert.That(result[0].Links, Is.Not.Null);
-            Assert.That(result[0].Links.Subscription, Is.Not.Null);
-            Assert.That(result[0].Metadata, Is.Not.Null);
-            Assert.That(result[0].ResourceType, Is.EqualTo(ResourceType.Subscriptions));
+            Assert.That(results.Any(), Is.True);
+            Assert.That(results[0], Is.Not.Null);
+            Assert.That(results[0].Id, Is.Not.Null);
+            Assert.That(results[0].Action, Is.Not.Null);
+            Assert.That(results[0].CreatedAt, Is.Not.Null.And.Not.EqualTo(default(DateTimeOffset)));
+            Assert.That(results[0].Details, Is.Not.Null);
+            Assert.That(results[0].Details.Cause, Is.Not.Null);
+            Assert.That(results[0].Details.Description, Is.Not.Null);
+            Assert.That(results[0].Details.Origin, Is.Not.Null);
+            Assert.That(results[0].Links, Is.Not.Null);
+            Assert.That(results[0].Links.Subscription, Is.Not.Null);
+            Assert.That(results[0].Metadata, Is.Not.Null);
+            Assert.That(results[0].ResourceType, Is.EqualTo(ResourceType.Subscriptions));
         }
 
         [Test]
@@ -283,24 +284,23 @@ namespace GoCardlessApi.Tests.Integration.Clients
             };
 
             // when
-            var result = (await _subject.GetPageAsync(options)).Items.ToList();
+            var results = (await _subject.GetPageAsync(options)).Items.ToList();
+            var actual = results.FirstOrDefault(x => x.Details.Currency != null);
 
             // then
-            Assert.That(result.Any(), Is.True);
-            Assert.That(result[0], Is.Not.Null);
-            Assert.That(result[0].Id, Is.Not.Null);
-            Assert.That(result[0].Action, Is.EqualTo(Actions.Creditor.NewPayoutCurrencyAdded));
-            Assert.That(result[0].CreatedAt, Is.Not.Null.And.Not.EqualTo(default(DateTimeOffset)));
-            Assert.That(result[0].Details, Is.Not.Null);
-            Assert.That(result[0].Details.BankAccountId, Is.Not.Null);
-            Assert.That(result[0].Details.Cause, Is.EqualTo(Causes.NewPayoutCurrencyAdded));
-            Assert.That(result[0].Details.Currency, Is.Not.Null);
-            Assert.That(result[0].Details.Description, Is.Not.Null);
-            Assert.That(result[0].Details.Origin, Is.EqualTo(Origin.GoCardless));
-            Assert.That(result[0].Links, Is.Not.Null);
-            Assert.That(result[0].Links.Creditor, Is.Not.Null);
-            Assert.That(result[0].Metadata, Is.Not.Null);
-            Assert.That(result[0].ResourceType, Is.EqualTo(ResourceType.Creditors));
+            Assert.That(actual, Is.Not.Null);
+            Assert.That(actual.Id, Is.Not.Null);
+            Assert.That(actual.Action, Is.EqualTo(Actions.Creditor.NewPayoutCurrencyAdded));
+            Assert.That(actual.CreatedAt, Is.Not.Null.And.Not.EqualTo(default(DateTimeOffset)));
+            Assert.That(actual.Details, Is.Not.Null);
+            Assert.That(actual.Details.BankAccountId, Is.Not.Null);
+            Assert.That(actual.Details.Cause, Is.EqualTo(Causes.NewPayoutCurrencyAdded));
+            Assert.That(actual.Details.Description, Is.Not.Null);
+            Assert.That(actual.Details.Origin, Is.EqualTo(Origin.GoCardless));
+            Assert.That(actual.Links, Is.Not.Null);
+            Assert.That(actual.Links.Creditor, Is.Not.Null);
+            Assert.That(actual.Metadata, Is.Not.Null);
+            Assert.That(actual.ResourceType, Is.EqualTo(ResourceType.Creditors));
         }
 
         [Test]
@@ -351,14 +351,14 @@ namespace GoCardlessApi.Tests.Integration.Clients
             };
 
             // when
-            var result = await _subject
+            var results = await _subject
                 .PageUsing(options)
                 .GetItemsAfterAsync();
 
             // then
-            Assert.That(result.Count, Is.GreaterThan(1));
-            Assert.That(result[0].Id, Is.Not.Null.And.Not.EqualTo(result[1].Id));
-            Assert.That(result[1].Id, Is.Not.Null.And.Not.EqualTo(result[0].Id));
+            Assert.That(results.Count, Is.GreaterThan(1));
+            Assert.That(results[0].Id, Is.Not.Null.And.Not.EqualTo(results[1].Id));
+            Assert.That(results[1].Id, Is.Not.Null.And.Not.EqualTo(results[0].Id));
         }
     }
 }

--- a/tests/GoCardless.Api.Tests.Integration/Clients/EventClientTests.cs
+++ b/tests/GoCardless.Api.Tests.Integration/Clients/EventClientTests.cs
@@ -40,6 +40,36 @@ namespace GoCardlessApi.Tests.Integration.Clients
         }
 
         [Test]
+        public async Task returns_creditor_events()
+        {
+            // given
+            var options = new GetEventsOptions
+            {
+                Action = Actions.Creditor.Updated,
+                ResourceType = ResourceType.Creditors
+            };
+
+            // when
+            var result = (await _subject.GetPageAsync(options)).Items.ToList();
+
+            // then
+            Assert.That(result.Any(), Is.True);
+            Assert.That(result[0], Is.Not.Null);
+            Assert.That(result[0].Id, Is.Not.Null);
+            Assert.That(result[0].Action, Is.EqualTo(Actions.Creditor.Updated));
+            Assert.That(result[0].CreatedAt, Is.Not.Null.And.Not.EqualTo(default(DateTimeOffset)));
+            Assert.That(result[0].Details, Is.Not.Null);
+            Assert.That(result[0].Details.Cause, Is.EqualTo(Causes.CreditorUpdated));
+            Assert.That(result[0].Details.Description, Is.Not.Null);
+            Assert.That(result[0].Details.Origin, Is.Not.Null);
+            Assert.That(result[0].Details.Property, Is.Not.Null);
+            Assert.That(result[0].Links, Is.Not.Null);
+            Assert.That(result[0].Links.Creditor, Is.Not.Null);
+            Assert.That(result[0].Metadata, Is.Not.Null);
+            Assert.That(result[0].ResourceType, Is.EqualTo(ResourceType.Creditors));
+        }
+
+        [Test]
         public async Task returns_mandate_events()
         {
             // given
@@ -64,7 +94,7 @@ namespace GoCardlessApi.Tests.Integration.Clients
             Assert.That(result[0].Links, Is.Not.Null);
             Assert.That(result[0].Links.Mandate, Is.Not.Null);
             Assert.That(result[0].Metadata, Is.Not.Null);
-            Assert.That(result[0].ResourceType, Is.Not.Null);
+            Assert.That(result[0].ResourceType, Is.EqualTo(ResourceType.Mandates));
         }
 
         [Test]
@@ -92,7 +122,7 @@ namespace GoCardlessApi.Tests.Integration.Clients
             Assert.That(result[0].Links, Is.Not.Null);
             Assert.That(result[0].Links.Payment, Is.Not.Null);
             Assert.That(result[0].Metadata, Is.Not.Null);
-            Assert.That(result[0].ResourceType, Is.Not.Null);
+            Assert.That(result[0].ResourceType, Is.EqualTo(ResourceType.Payments));
         }
 
         [Test]
@@ -120,7 +150,7 @@ namespace GoCardlessApi.Tests.Integration.Clients
             Assert.That(result[0].Links, Is.Not.Null);
             Assert.That(result[0].Links.Payout, Is.Not.Null);
             Assert.That(result[0].Metadata, Is.Not.Null);
-            Assert.That(result[0].ResourceType, Is.Not.Null);
+            Assert.That(result[0].ResourceType, Is.EqualTo(ResourceType.Payouts));
         }
 
         [Test]
@@ -148,7 +178,7 @@ namespace GoCardlessApi.Tests.Integration.Clients
             Assert.That(result[0].Links, Is.Not.Null);
             Assert.That(result[0].Links.Refund, Is.Not.Null);
             Assert.That(result[0].Metadata, Is.Not.Null);
-            Assert.That(result[0].ResourceType, Is.Not.Null);
+            Assert.That(result[0].ResourceType, Is.EqualTo(ResourceType.Refunds));
         }
 
         [Test]
@@ -176,7 +206,7 @@ namespace GoCardlessApi.Tests.Integration.Clients
             Assert.That(result[0].Links, Is.Not.Null);
             Assert.That(result[0].Links.Subscription, Is.Not.Null);
             Assert.That(result[0].Metadata, Is.Not.Null);
-            Assert.That(result[0].ResourceType, Is.Not.Null);
+            Assert.That(result[0].ResourceType, Is.EqualTo(ResourceType.Subscriptions));
         }
 
         [Test]
@@ -228,18 +258,49 @@ namespace GoCardlessApi.Tests.Integration.Clients
             Assert.That(result.Any(), Is.True);
             Assert.That(result[0], Is.Not.Null);
             Assert.That(result[0].Id, Is.Not.Null);
-            Assert.That(result[0].Action, Is.Not.Null);
+            Assert.That(result[0].Action, Is.EqualTo(Actions.Payment.PaidOut));
             Assert.That(result[0].CreatedAt, Is.Not.Null.And.Not.EqualTo(default(DateTimeOffset)));
             Assert.That(result[0].Details, Is.Not.Null);
-            Assert.That(result[0].Details.Cause, Is.Not.Null);
+            Assert.That(result[0].Details.Cause, Is.EqualTo(Causes.PaymentPaidOut));
             Assert.That(result[0].Details.Description, Is.Not.Null);
-            Assert.That(result[0].Details.Origin, Is.Not.Null);
+            Assert.That(result[0].Details.Origin, Is.EqualTo(Origin.GoCardless));
             Assert.That(result[0].Links, Is.Not.Null);
             Assert.That(result[0].Links.ParentEvent, Is.Not.Null);
             Assert.That(result[0].Links.Payment, Is.Not.Null);
             Assert.That(result[0].Links.Payout, Is.Not.Null);
             Assert.That(result[0].Metadata, Is.Not.Null);
-            Assert.That(result[0].ResourceType, Is.Not.Null);
+            Assert.That(result[0].ResourceType, Is.EqualTo(ResourceType.Payments));
+        }
+
+        [Test]
+        public async Task maps_bank_account_id_and_currency()
+        {
+            // given
+            var options = new GetEventsOptions
+            {
+                Action = Actions.Creditor.NewPayoutCurrencyAdded,
+                ResourceType = ResourceType.Creditors
+            };
+
+            // when
+            var result = (await _subject.GetPageAsync(options)).Items.ToList();
+
+            // then
+            Assert.That(result.Any(), Is.True);
+            Assert.That(result[0], Is.Not.Null);
+            Assert.That(result[0].Id, Is.Not.Null);
+            Assert.That(result[0].Action, Is.EqualTo(Actions.Creditor.NewPayoutCurrencyAdded));
+            Assert.That(result[0].CreatedAt, Is.Not.Null.And.Not.EqualTo(default(DateTimeOffset)));
+            Assert.That(result[0].Details, Is.Not.Null);
+            Assert.That(result[0].Details.BankAccountId, Is.Not.Null);
+            Assert.That(result[0].Details.Cause, Is.EqualTo(Causes.NewPayoutCurrencyAdded));
+            Assert.That(result[0].Details.Currency, Is.Not.Null);
+            Assert.That(result[0].Details.Description, Is.Not.Null);
+            Assert.That(result[0].Details.Origin, Is.EqualTo(Origin.GoCardless));
+            Assert.That(result[0].Links, Is.Not.Null);
+            Assert.That(result[0].Links.Creditor, Is.Not.Null);
+            Assert.That(result[0].Metadata, Is.Not.Null);
+            Assert.That(result[0].ResourceType, Is.EqualTo(ResourceType.Creditors));
         }
 
         [Test]


### PR DESCRIPTION
GoCardless documentation states: 

> When we send a creditor new_payout_currency_added webhook, we also send the currency of the new account

My tests confirm this is not the case, and so I've had to change the assertion here to look for an object where `currency != null`. It seems an event for the default currency is being raised when it shouldn't be, and these events don't contain the currency in the JSON payload.